### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Include `angular-linkify.min.js` in your angular application
 <script src="node_modules/angular-linkify/angular-linkify.min.js"></script>
 
 <!-- when using cdn file -->
-<script src="//cdn.jsdelivr.net/angular.linkify/2.0.0/angular-linkify.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/angular-linkify@2.0.0/angular-linkify.min.js"></script>
 
 <!-- when using downloaded files -->
 <script src="angular-linkify.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/angular-linkify.

Feel free to ping me if you have any questions regarding this change.